### PR TITLE
bug: build should not throw

### DIFF
--- a/shared/builder/lib/asset-compilers/index.js
+++ b/shared/builder/lib/asset-compilers/index.js
@@ -21,9 +21,7 @@ COMPILERS['.js'] = function(source, cb) {
         });
     }
     catch (err) {
-        console.error('\n' + err.name + ':', err.message);
-        cb(err.codeFrame);
-        return;
+        return cb(err);
     }
     cb(null, result.code);
 };
@@ -118,14 +116,17 @@ function compileSource(source, path, cb) {
     if (hasCompilerFor(extname)) {
         COMPILERS[extname](source, function(err, result) {
             if (err) {
-                console.error(err);
+                console.error('\n' + err.name + ':', err.message);
+                console.log(err.codeframe);
+                result = 'console.log("error in file: ' + path + '");';
+                result += 'console.log("' + err.name + ':' + err.message + '")';
+                console.log(result);
             }
-            else {
-                cb(null, {
-                    path: compiledPath(path),
-                    content: result
-                });
-            }
+
+            return cb(null, {
+                path: compiledPath(path),
+                content: result
+            });
         });
     }
     else {


### PR DESCRIPTION
```
This fix catches an edge case where the build process would stop running if babel failed.

New exit no longer fails and prints to your browser console the babel error
```
