### PR TITLE
Improvements to local-workspace template

### DIFF
--- a/dev/local-workspace/assets/main.css
+++ b/dev/local-workspace/assets/main.css
@@ -4,6 +4,18 @@ html, body {
     font-family: 'Lato', Helvetica, Arial, sans-serif;
 }
 
+body.hide-navigation #famous-framework-stage {
+    height: 100%;
+}
+
+body.hide-navigation #nav {
+    visibility: hidden;
+}
+
+body.hide-search #famous-framework-components-search {
+    visibility: hidden;
+}
+
 #famous-framework-stage {
     height: 90%;
     position: relative;

--- a/dev/local-workspace/assets/search.js
+++ b/dev/local-workspace/assets/search.js
@@ -30,19 +30,15 @@
     }
 
     searchBtn.addEventListener('click', function() {
-        if (searchContainer.className === '') {
-            searchContainer.className = 'active';
+        searchContainer.classList.toggle('active');
+        if (searchContainer.classList.contains('active')) {
             searchInput.focus();
             searchInput.select();
-        }
-        else {
-            searchContainer.className = '';
         }
     });
 
     searchDropdown.addEventListener('click', function() {
-        if (searchContainer.className === 'active') searchContainer.className = 'active expanded';
-        else searchContainer.className = 'active';
+        searchContainer.classList.toggle('expanded');
     });
 
     [].forEach.call(searchScenesOptions, function(li) {

--- a/dev/local-workspace/assets/search.js
+++ b/dev/local-workspace/assets/search.js
@@ -44,6 +44,8 @@
     [].forEach.call(searchScenesOptions, function(li) {
         li.addEventListener('click', function(event) {
             updateCurrentModule(event.currentTarget.textContent);
+            searchContainer.classList.remove('active');
+            searchContainer.classList.remove('expanded');
         });
     });
 

--- a/dev/local-workspace/assets/search.js
+++ b/dev/local-workspace/assets/search.js
@@ -24,7 +24,28 @@
         currentModule = name;
         modSpan.innerText = name;
         searchInput.value = name;
-        window.history.pushState(name, 'Famous Framework (workspace)', '?ff=' + name);
+
+        var searchStr = '?ff=' + name;
+
+        if ('navigation' in QUERY) {
+            if (QUERY.navigation === true) {
+                document.body.classList.remove('hide-navigation');
+            } else if (QUERY.navigation === false) {
+                document.body.classList.add('hide-navigation');
+            }
+            searchStr += '&navigation=' + QUERY.navigation.toString();
+        }
+
+        if ('search' in QUERY) {
+            if (QUERY.search === true) {
+                document.body.classList.remove('hide-search');
+            } else if (QUERY.search === false) {
+                document.body.classList.add('hide-search');
+            }
+            searchStr += '&search=' + QUERY.search.toString();
+        }
+
+        window.history.pushState(name, 'Famous Framework (workspace)', searchStr);
 
         var delimitedSafe = name.split(COMPONENT_DELIMITER).join(SAFE_NAMESPACE_DELIMITER);
         iframe.setAttribute('src', 'build/' + delimitedSafe + '/index.html');

--- a/dev/local-workspace/assets/search.js
+++ b/dev/local-workspace/assets/search.js
@@ -5,6 +5,7 @@
     var searchContainer = document.getElementById('famous-framework-components-search');
     var searchBtn = searchContainer.querySelector('.famous-framework-components-search-btn');
     var searchDropdown = searchContainer.querySelector('.famous-framework-components-search-dropdown');
+    var searchForm = searchContainer.querySelector('form');
     var searchScenes = searchContainer.querySelector('ul');
     var searchInput = searchContainer.querySelector('input');
     var searchScenesOptions = searchScenes.querySelectorAll('li');
@@ -40,6 +41,12 @@
     searchDropdown.addEventListener('click', function() {
         searchContainer.classList.toggle('expanded');
     });
+
+    searchForm.onsubmit = function() {
+        updateCurrentModule(searchInput.value);
+        searchContainer.classList.remove('active');
+        return false;
+    };
 
     [].forEach.call(searchScenesOptions, function(li) {
         li.addEventListener('click', function(event) {


### PR DESCRIPTION
This PR contains a number of improvements to `local-workspace` template.

* Simplified code using [classList Web API](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList).
* Hide dropdown from search container on item selection.
* Improved search experience by avoiding to reload entire page on search.
* Added `navigation=false&search=false` options to hide navigation/search separately. (based on discussion with @matthewtoast on Slack)