### PR TITLE
Guard node.setSizeMode() against null values in "famous:core:node"

### DIFF
--- a/lib/core-components/famous/core/node/node.js
+++ b/lib/core-components/famous/core/node/node.js
@@ -216,51 +216,99 @@ FamousFramework.module('famous:core:node', {
                 $famousNode.setSizeMode(null, null, 2);
             },
             'size-absolute': function($famousNode, $payload) {
-                $famousNode.setSizeMode(1, 1, 1);
+                $famousNode.setSizeMode(
+                    $payload[0] === null ? null : 1,
+                    $payload[1] === null ? null : 1,
+                    $payload[2] === null ? null : 1
+                );
                 $famousNode.setAbsoluteSize($payload[0], $payload[1], $payload[2]);
             },
             'size-absolute-x': function($famousNode, $payload) {
-                $famousNode.setSizeMode(1, null, null);
+                $famousNode.setSizeMode(
+                    $payload === null ? null : 1,
+                    null,
+                    null
+                );
                 $famousNode.setAbsoluteSize($payload, null, null);
             },
             'size-absolute-y': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, 1, null);
+                $famousNode.setSizeMode(
+                    null,
+                    $payload === null ? null : 1,
+                    null
+                );
                 $famousNode.setAbsoluteSize(null, $payload, null);
             },
             'size-absolute-z': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, null, 1);
+                $famousNode.setSizeMode(
+                    null,
+                    null,
+                    $payload === null ? null : 1
+                );
                 $famousNode.setAbsoluteSize(null, null, $payload);
             },
             'size-differential': function($famousNode, $payload) {
-                $famousNode.setSizeMode(0, 0, 0);
+                $famousNode.setSizeMode(
+                    $payload[0] === null ? null : 0,
+                    $payload[1] === null ? null : 0,
+                    $payload[2] === null ? null : 0
+                );
                 $famousNode.setDifferentialSize($payload[0], $payload[1], $payload[2]);
             },
             'size-differential-x': function($famousNode, $payload) {
-                $famousNode.setSizeMode(0, null, null);
+                $famousNode.setSizeMode(
+                    $payload === null ? null : 0,
+                    null,
+                    null
+                );
                 $famousNode.setDifferentialSize($payload, null, null);
             },
             'size-differential-y': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, 0, null);
+                $famousNode.setSizeMode(
+                    null,
+                    $payload === null ? null : 0,
+                    null
+                );
                 $famousNode.setDifferentialSize(null, $payload, null);
             },
             'size-differential-z': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, null, 0);
+                $famousNode.setSizeMode(
+                    null,
+                    null,
+                    $payload === null ? null : 0
+                );
                 $famousNode.setDifferentialSize(null, null, $payload);
             },
             'size-proportional': function($famousNode, $payload) {
-                $famousNode.setSizeMode(0, 0, 0);
+                $famousNode.setSizeMode(
+                    $payload[0] === null ? null : 0,
+                    $payload[1] === null ? null : 0,
+                    $payload[2] === null ? null : 0
+                );
                 $famousNode.setProportionalSize($payload[0], $payload[1], $payload[2]);
             },
             'size-proportional-x': function($famousNode, $payload) {
-                $famousNode.setSizeMode(0, null, null);
+                $famousNode.setSizeMode(
+                    $payload === null ? null : 0,
+                    null,
+                    null
+                );
                 $famousNode.setProportionalSize($payload, null, null);
             },
             'size-proportional-y': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, 0, null);
+                $famousNode.setSizeMode(
+                    null,
+                    $payload === null ? null : 0,
+                    null
+                );
                 $famousNode.setProportionalSize(null, $payload, null);
             },
             'size-proportional-z': function($famousNode, $payload) {
-                $famousNode.setSizeMode(null, null, 0);
+                $famousNode.setSizeMode(
+                    null,
+                    null,
+                    $payload === null ? null : 0
+                );
                 $famousNode.setProportionalSize(null, null, $payload);
             },
             'style': function($DOMElement, $payload) {


### PR DESCRIPTION
There is a case where a behavior sends an event to node (ex: `size-absolute-x`) with `$payload` being either actual size value or `null` depends on repeat `$index` as follows:

```js
{
  '$repeat': [...],
  'size-absolute-x': function($index) {
    return ($index % 2 === 0) ? null : 10;
  }
}
```

This PR adds `null` guards to all `$public` events within `famous:core:node` such that internally it does not update `node.setSizeMode` with incorrect value when `$payload === null`.