### PR TITLE
Dropped "set-" naming convention for consistency

### DIFF
--- a/lib/behaviors/behaviors.js
+++ b/lib/behaviors/behaviors.js
@@ -100,20 +100,16 @@ Behaviors.cameraBehavior = function cameraBehavior(behavior, component) {
         case 'set':
             camera.set(payload[0], payload[1], payload[2], payload[3]);
             break;
-        case 'setDepth':
-        case 'set-depth':
+        case 'depth':
             camera.setDepth(payload[0]);
             break;
-        case 'setFlat':
-        case 'set-flat':
+        case 'flat':
             camera.setFlat();
             break;
-        case 'setFrustum':
-        case 'set-frustum':
+        case 'frustum':
             camera.setFrustum(payload[0], payload[1]);
             break;
-        case 'setValue':
-        case 'set-value':
+        case 'value':
             camera.setValue(payload[0]);
             break;
     }

--- a/lib/core-components/famous-demos/best/demo/demo.js
+++ b/lib/core-components/famous-demos/best/demo/demo.js
@@ -5,7 +5,7 @@ FamousFramework.scene('famous-demos:best:demo', {
             'rotation-x': Math.PI/4
         },
         '$camera': {
-            'set-depth': 4000
+            'depth': 4000
         },
         '#square': {
             '$repeat': [

--- a/lib/core-components/famous-tests/camera/camera.js
+++ b/lib/core-components/famous-tests/camera/camera.js
@@ -3,7 +3,7 @@ var angle = Math.PI / 5;
 FamousFramework.scene('famous-tests:camera', {
     behaviors: {
         '$camera': {
-            'set-depth': '[[identity|depth]]'
+            'depth': '[[identity]]'
         },
         '$self': {
             'unselectable': true

--- a/lib/core-components/famous-tests/custom-famous-node/custom-famous-node.js
+++ b/lib/core-components/famous-tests/custom-famous-node/custom-famous-node.js
@@ -1,10 +1,10 @@
 FamousFramework.scene('famous-tests:custom-famous-node', {
     behaviors: {
         '$self' : {
-            'set-top-padding' : '[[identity|topPadding]]',
-            'set-bottom-padding' : '[[identity|bottomPadding]]',
-            'set-left-padding' : '[[identity|leftPadding]]',
-            'set-right-padding' : '[[identity|rightPadding]]',
+            'top-padding' : '[[identity|topPadding]]',
+            'bottom-padding' : '[[identity|bottomPadding]]',
+            'left-padding' : '[[identity|leftPadding]]',
+            'right-padding' : '[[identity|rightPadding]]',
         },
         'node':  {
             style: {
@@ -14,22 +14,22 @@ FamousFramework.scene('famous-tests:custom-famous-node', {
     },
     events: {
         $public: {
-            'set-top-padding' : '[[setter|camel]]',
-            'set-right-padding' : '[[setter|camel]]',
-            'set-bottom-padding' : '[[setter|camel]]',
-            'set-left-padding' : '[[setter|camel]]'
+            'top-padding' : '[[setter|camel]]',
+            'right-padding' : '[[setter|camel]]',
+            'bottom-padding' : '[[setter|camel]]',
+            'left-padding' : '[[setter|camel]]'
         },
         '$private' : {
-            'set-top-padding' : function($famousNode, $payload) {
+            'top-padding' : function($famousNode, $payload) {
                 $famousNode.setTopPadding($payload);
             },
-            'set-right-padding' : function($famousNode, $payload) {
+            'right-padding' : function($famousNode, $payload) {
                 $famousNode.setRightPadding($payload);
             },
-            'set-bottom-padding' : function($famousNode, $payload) {
+            'bottom-padding' : function($famousNode, $payload) {
                 $famousNode.setBottomPadding($payload);
             },
-            'set-left-padding' : function($famousNode, $payload) {
+            'left-padding' : function($famousNode, $payload) {
                 $famousNode.setLeftPadding($payload);
             }
         }

--- a/lib/core-components/famous-tests/dispatcher/broadcasting/broadcasting.js
+++ b/lib/core-components/famous-tests/dispatcher/broadcasting/broadcasting.js
@@ -7,7 +7,7 @@ FamousFramework.scene('famous-tests:dispatcher:broadcasting', {
     events: {
         '#parent': {
             'click': function($dispatcher) {
-                $dispatcher.broadcast('set-child-size', [600, 600]);
+                $dispatcher.broadcast('child-size', [600, 600]);
             }
         }
     },

--- a/lib/core-components/famous-tests/dispatcher/broadcasting/child/child.js
+++ b/lib/core-components/famous-tests/dispatcher/broadcasting/child/child.js
@@ -16,7 +16,7 @@ FamousFramework.scene('famous-tests:dispatcher:broadcasting:child', {
     },
     events: {
         '#child': {
-            'set-child-size': function($state, $payload) {
+            'child-size': function($state, $payload) {
                 $state.set('childSize', $payload, { duration: 400, curve: 'outBack' });
             }
         }

--- a/lib/core-components/famous-tests/physics/basic/gravity/gravity.js
+++ b/lib/core-components/famous-tests/physics/basic/gravity/gravity.js
@@ -1,7 +1,7 @@
 FamousFramework.scene('famous-tests:physics:basic:gravity', {
     behaviors: {
         '$camera': {
-            'set-depth': 1000
+            'depth': 1000
         },
         '.sphere': {
             'size': [100, 100],

--- a/lib/core-components/famous-tests/webgl/custom-shader/vertex/vertex.js
+++ b/lib/core-components/famous-tests/webgl/custom-shader/vertex/vertex.js
@@ -1,7 +1,7 @@
 FamousFramework.scene('famous-tests:webgl:custom-shader:vertex', {
     behaviors: {
         '$camera': {
-            'set-depth': 1000
+            'depth': 1000
         },
         '.sphere': {
             'size': [200, 200],

--- a/lib/events/events.js
+++ b/lib/events/events.js
@@ -210,7 +210,7 @@ Used to find behavior handlers for behavior's with '$self' selector:
 i.e.:
 behaviors
     $self
-        set-content =>
+        content =>
 
 $private takes precendence of $public
  */


### PR DESCRIPTION
There is inconsistency in event naming styles. This PR changes it for consistency and to avoid giving the wrong idea. (change `set-XXX` to just `XXX`)

@matthewtoast on Slack:
> instead of `set-foo` it'd be more appropriate to call it `request-foo-change` or something