### PR TITLE
Adds a missing <div> to "famous-tests:state-manager-test" tree

### DIFF
--- a/lib/core-components/famous-tests/state-manager-test/state-manager-test.js
+++ b/lib/core-components/famous-tests/state-manager-test/state-manager-test.js
@@ -29,5 +29,9 @@ FamousFramework.scene('famous-tests:state-manager-test', {
         size: [250, 250],
         position: [0, 0]
     },
-    tree: '<node id="element">Click Here</node>'
+    tree: `
+        <node id="element">
+            <div>Click Here</div>
+        </node>
+    `
 });


### PR DESCRIPTION
This PR adds a missing `<div>` to "famous-tests:state-manager-test" tree.