### PR TITLE
Add size-mode public events to "famous:core:node"

### DIFF
--- a/lib/core-components/famous/core/node/node.js
+++ b/lib/core-components/famous/core/node/node.js
@@ -203,6 +203,18 @@ FamousFramework.module('famous:core:node', {
                 if (zSize === true) $dispatcher.trigger('size-true-z');
                 else if (zSize !== undefined) $dispatcher.trigger('size-absolute-z', zSize);
             },
+            'size-mode': function($famousNode, $payload) {
+                $famousNode.setSizeMode($payload[0], $payload[1], $payload[2]);
+            },
+            'size-mode-x': function($famousNode, $payload) {
+                $famousNode.setSizeMode($payload, null, null);
+            },
+            'size-mode-y': function($famousNode, $payload) {
+                $famousNode.setSizeMode(null, $payload, null);
+            },
+            'size-mode-z': function($famousNode, $payload) {
+                $famousNode.setSizeMode(null, null, $payload);
+            },
             'size-true': function($famousNode) {
                 $famousNode.setSizeMode(2, 2, 2);
             },


### PR DESCRIPTION
This PR adds the following missing events to `famous:core:node` component:
* `size-mode`
* `size-mode-x`
* `size-mode-y`
* `size-mode-z`

Foundational layout examples will need these.