### PR TITLE
Add Flexible Layout w/ examples

### DIFF
--- a/lib/core-components/famous-demos/layouts/flexible/header-footer/header-footer.js
+++ b/lib/core-components/famous-demos/layouts/flexible/header-footer/header-footer.js
@@ -1,0 +1,40 @@
+FamousFramework.component('famous-demos:layouts:flexible:header-footer', {
+    behaviors: {
+        'famous:layouts:flexible': {
+            'direction': 1,
+            'ratios': [true, 1, true]
+        },
+        '.header': {
+            'content': 'HEADER',
+            'size-absolute-y': 100,
+            'style': {
+                'background-color': '#000',
+                'color': '#fff'
+            }
+        },
+        '.body': {
+            'content': 'BODY',
+            'style': {
+                'background-color': '#ddd',
+                'color': '#000'
+            }
+        },
+        '.footer': {
+            'content': 'FOOTER',
+            'size-absolute-y': 50,
+            'style': {
+                'background-color': '#555',
+                'color': '#fff'
+            }
+        }
+    },
+    events: {},
+    states: {},
+    tree: `
+        <famous:layouts:flexible>
+            <node class="header"></node>
+            <node class="body"></node>
+            <node class="footer"></node>
+        </famous:layouts:flexible>
+    `
+});

--- a/lib/core-components/famous-demos/layouts/flexible/nested/nested.js
+++ b/lib/core-components/famous-demos/layouts/flexible/nested/nested.js
@@ -1,0 +1,58 @@
+FamousFramework.component('famous-demos:layouts:flexible:nested', {
+    behaviors: {
+        '.wrapper': {
+            'direction': 0,
+            'ratios': [3, true, 1, true, 2]
+        },
+        '.first': {
+            'direction': 1,
+            'ratios': [1, true, 5]
+        },
+        '.second': {
+            'direction': 0,
+            'ratios': [1]
+        },
+        '.third': {
+            'direction': 1,
+            'ratios': [5, true, 1]
+        },
+        '.item': {
+            'style': {
+                'background-color': '#000',
+                'color': '#fff'
+            }
+        },
+        '.splitter': {
+            'style': {
+                'background-color': '#fff'
+            }
+        },
+        '.horizontal.splitter': {
+            'size-absolute-y': 1,
+        },
+        '.vertical.splitter': {
+            'size-absolute-x': 1,
+        }
+    },
+    events: {},
+    states: {},
+    tree: `
+        <famous:layouts:flexible class="wrapper">
+            <famous:layouts:flexible class="first">
+                <node class="item"><div>1</div></node>
+                <node class="horizontal splitter"></node>
+                <node class="item"><div>2</div></node>
+            </famous:layouts:flexible>
+            <node class="vertical splitter"></node>
+            <famous:layouts:flexible class="second">
+                <node class="item"><div>3</div></node>
+            </famous:layouts:flexible>
+            <node class="vertical splitter"></node>
+            <famous:layouts:flexible class="third">
+                <node class="item"><div>4</div></node>
+                <node class="horizontal splitter"></node>
+                <node class="item"><div>5</div></node>
+            </famous:layouts:flexible>
+        </famous:layouts:flexible>
+    `
+});

--- a/lib/core-components/famous-demos/layouts/flexible/simple/simple.js
+++ b/lib/core-components/famous-demos/layouts/flexible/simple/simple.js
@@ -1,0 +1,39 @@
+FamousFramework.component('famous-demos:layouts:flexible:simple', {
+    behaviors: {
+        'famous:layouts:flexible': {
+            'direction': 0,
+            'ratios': [1, true, 2, true, 5, true, 10, true, 5, true, 2, true, 1]
+        },
+        '.item': {
+            'style': {
+                'background-color': '#000',
+                'color': '#fff'
+            }
+        },
+        '.splitter': {
+            'size-absolute-x': 1,
+            'style': {
+                'background-color': '#fff'
+            }
+        }
+    },
+    events: {},
+    states: {},
+    tree: `
+        <famous:layouts:flexible>
+            <node class="item"><div>1</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>2</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>5</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>10</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>5</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>2</div></node>
+            <node class="splitter"></node>
+            <node class="item"><div>1</div></node>
+        </famous:layouts:flexible>
+    `
+});

--- a/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
+++ b/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
@@ -1,0 +1,120 @@
+const COLORS = [
+    'rgba(255, 0, 0, .7)',
+    'rgba(0, 255, 0, .7)',
+    'rgba(0, 0, 255, .7)',
+    'rgba(255, 0, 0, .7)',
+    'rgba(0, 255, 0, .7)',
+    'rgba(0, 0, 255, .7)',
+    'rgba(255, 0, 0, .7)',
+    'rgba(0, 255, 0, .7)'
+];
+const INITIAL_RATIOS = [1, true, 1, true, 1, true, 1, true];
+const FINAL_RATIOS = [4, true, 1, true, 0, true, 7, true];
+
+FamousFramework.component('famous-demos:layouts:flexible:transition', {
+    behaviors: {
+        '$self': {
+            'unselectable': true
+        },
+        '.title': {
+            'align': [0.5, 1],
+            'mount-point': [0.5, 1],
+            'position-y': -25,
+            'size-differential-x': -50,
+            'size-absolute-y': 50,
+            'content': (direction, ratios, transition) => {
+                return `
+                    < Ratios: ${JSON.stringify(ratios)} >
+                    &bull;
+                    < Direction: ${JSON.stringify(direction)} >
+                    &bull;
+                    < Transition: ${JSON.stringify(transition)} >
+                `;
+            },
+            'style': {
+                'background-color': 'rgba(0, 0, 0, 0.5)',
+                'border-radius': '50px',
+                'color': '#fff',
+                'line-height': '50px',
+                'text-align': 'center',
+                'z-index': 1000
+            }
+        },
+        'famous:layouts:flexible': {
+            'direction': '[[identity]]',
+            'ratios': '[[identity]]',
+            'transition': '[[identity]]'
+        },
+        '.flexible-layout-item': {
+            '$repeat': '[[identity|colors]]',
+            'size-mode': (direction) => {
+                return [0, 0, 0].map((value, idx) => {
+                    if (idx === direction) {
+                        return null;
+                    }
+                    return value;
+                });
+            },
+            'size-absolute': ($index, direction) => {
+                return [null, null, null].map((value, idx) => {
+                    if (idx === direction && $index % 2 !== 0) {
+                        return 10;
+                    }
+                    return value;
+                });
+            },
+            'style': ($index, colors) => {
+                return {
+                    'background-color': colors[$index]
+                };
+            }
+        }
+    },
+    events: {
+        '$lifecycle': {
+            'post-load': ($dispatcher) => {
+                $dispatcher.trigger('toggle-direction');
+                $dispatcher.trigger('toggle-ratios');
+            }
+        },
+        '$self': {
+            'click': ($dispatcher, $state) => {
+                $dispatcher.trigger('toggle-ratios');
+                if ($state.get('clickCount') % 2 !== 0) {
+                    $dispatcher.trigger('toggle-direction');
+                }
+                $state.set('clickCount', $state.get('clickCount') + 1);
+            }
+        },
+        '$public': {
+            'toggle-direction': ($state) => {
+                $state.set('directionToggled', !$state.get('directionToggled'));
+                setTimeout(() => {
+                    $state.set('direction', $state.get('directionToggled') ? 0 : 1);
+                }, $state.get(['transition', 'duration']) + 200);
+            },
+            'toggle-ratios': ($state) => {
+                $state.set('ratioToggled', !$state.get('ratioToggled'));
+                $state.set('ratios', $state.get('ratioToggled') ? INITIAL_RATIOS : FINAL_RATIOS);
+            }
+        }
+    },
+    states: {
+        clickCount: 0,
+        colors: COLORS,
+        direction: null,
+        directionToggled: false,
+        ratios: null,
+        ratioToggled: false,
+        transition: {
+            curve: 'elasticInOut',
+            duration: 300
+        }
+    },
+    tree: `
+        <node class="title"></node>
+        <famous:layouts:flexible>
+            <node class="flexible-layout-item"></node>
+        </famous:layouts:flexible>
+    `
+});

--- a/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
+++ b/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
@@ -88,14 +88,17 @@ FamousFramework.component('famous-demos:layouts:flexible:transition', {
         },
         '$public': {
             'toggle-direction': ($state, $payload) => {
-                $state.set('directionToggled', !$state.get('directionToggled'));
+                let direction = $state.get('directionToggled') ? 1 : 0;
+
                 if ($payload) {
-                    $state.set('direction', $state.get('directionToggled') ? 0 : 1);
+                    $state.set('direction', direction);
                 } else {
                     setTimeout(() => {
-                        $state.set('direction', $state.get('directionToggled') ? 0 : 1);
+                        $state.set('direction', direction);
                     }, $state.get(['transition', 'duration']) + 200);
                 }
+
+                $state.set('directionToggled', !$state.get('directionToggled'));
             },
             'toggle-ratios': ($state) => {
                 $state.set('ratioToggled', !$state.get('ratioToggled'));

--- a/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
+++ b/lib/core-components/famous-demos/layouts/flexible/transition/transition.js
@@ -73,7 +73,7 @@ FamousFramework.component('famous-demos:layouts:flexible:transition', {
     events: {
         '$lifecycle': {
             'post-load': ($dispatcher) => {
-                $dispatcher.trigger('toggle-direction');
+                $dispatcher.trigger('toggle-direction', true);
                 $dispatcher.trigger('toggle-ratios');
             }
         },
@@ -81,17 +81,21 @@ FamousFramework.component('famous-demos:layouts:flexible:transition', {
             'click': ($dispatcher, $state) => {
                 $dispatcher.trigger('toggle-ratios');
                 if ($state.get('clickCount') % 2 !== 0) {
-                    $dispatcher.trigger('toggle-direction');
+                    $dispatcher.trigger('toggle-direction', false);
                 }
                 $state.set('clickCount', $state.get('clickCount') + 1);
             }
         },
         '$public': {
-            'toggle-direction': ($state) => {
+            'toggle-direction': ($state, $payload) => {
                 $state.set('directionToggled', !$state.get('directionToggled'));
-                setTimeout(() => {
+                if ($payload) {
                     $state.set('direction', $state.get('directionToggled') ? 0 : 1);
-                }, $state.get(['transition', 'duration']) + 200);
+                } else {
+                    setTimeout(() => {
+                        $state.set('direction', $state.get('directionToggled') ? 0 : 1);
+                    }, $state.get(['transition', 'duration']) + 200);
+                }
             },
             'toggle-ratios': ($state) => {
                 $state.set('ratioToggled', !$state.get('ratioToggled'));

--- a/lib/core-components/famous/layouts/flexible/_constructor.js
+++ b/lib/core-components/famous/layouts/flexible/_constructor.js
@@ -1,0 +1,153 @@
+const Node = FamousFramework.FamousEngine.core.Node;
+const Position = FamousFramework.FamousEngine.components.Position;
+const Size = FamousFramework.FamousEngine.components.Size;
+
+class FlexibleLayout extends Node {
+    constructor() {
+        super();
+
+        this._sizeSet = false;
+        this._direction = FlexibleLayout.Direction.X;
+        this._proportions = [];
+        this._ratios = [];
+        this._transition = null;
+
+        this.addComponent({
+            onSizeChange: () => {
+                this._sizeSet = true;
+                this._updateLayout();
+            }
+        });
+    }
+
+    _getDirectionIndex() {
+        if (this._direction === FlexibleLayout.Direction.X) {
+            return 0;
+        } else if (this._direction === FlexibleLayout.Direction.Y) {
+            return 1;
+        } else if (this._direction === FlexibleLayout.Direction.Z) {
+            return 2;
+        }
+        throw new Error(`Unknown direction - ${this._direction}`);
+    }
+
+    _createSizeArrayWithTrueSizesPopulated(childNodes, directionIndex) {
+        return this._proportions.map((proportion, idx) => {
+            if (idx < childNodes.length && proportion === true) {
+                let childNodeContent = childNodes[idx].getChildren()[0];
+                return childNodeContent.getAbsoluteSize()[directionIndex];
+            }
+            return null;
+        });
+    }
+
+    _calculateSumOfTrueSizes(sizes) {
+        return sizes
+            .filter((size) => typeof size === 'number')
+            .reduce((sum, size) => sum + size, 0);
+    }
+
+    _fillUnknownSizes(sizes, parentSize, sumTrueSizes) {
+        sizes.forEach((size, idx) => {
+            if (typeof size === 'number') {return;}
+            let proportion = this._proportions[idx];
+            if (typeof proportion === 'number') {
+                sizes[idx] = proportion * (parentSize - sumTrueSizes);
+            } else {
+                sizes[idx] = 0;
+            }
+        });
+    }
+
+    _createArrayWithValueAtDirectionIndex(value, array) {
+        let directionIndex = this._getDirectionIndex();
+        array[directionIndex] = value;
+        return array;
+    }
+
+    _updateLayout() {
+        if (!this._sizeSet || !this.getParent()) {return;}
+
+        let childNodes = this.getChildren()[0].getChildren();
+        let directionIndex = this._getDirectionIndex();
+        let parentSize = this.getParent().getSize();
+        let sizes = this._createSizeArrayWithTrueSizesPopulated(childNodes, directionIndex);
+        let sumTrueSizes = this._calculateSumOfTrueSizes(sizes);
+
+        this._fillUnknownSizes(sizes, parentSize[directionIndex], sumTrueSizes);
+
+        let position = 0;
+        childNodes.forEach((childNode, idx) => {
+            if (!childNode._layoutPosition) {
+                childNode._layoutPosition = new Position(childNode);
+            }
+            if (!childNode._layoutSize) {
+                childNode._layoutSize = new Size(childNode);
+            }
+
+            let size = sizes[idx];
+            let transition = this._transition;
+
+            childNode._layoutSize.setMode.apply(childNode._layoutSize, [1, 1, 1]);
+            childNode._layoutSize.setAbsolute.apply(
+                childNode._layoutSize,
+                this._createArrayWithValueAtDirectionIndex(size, [
+                    parentSize[0],
+                    parentSize[1],
+                    parentSize[2],
+                    transition
+                ])
+            );
+            childNode._layoutPosition.set.apply(
+                childNode._layoutPosition,
+                this._createArrayWithValueAtDirectionIndex(position, [0, 0, 0, transition])
+            );
+
+            position += size;
+        });
+    }
+
+    setDirection(direction) {
+        for (let key in FlexibleLayout.Direction) {
+            if (FlexibleLayout.Direction[key] === direction) {
+                this._direction = direction;
+                this._updateLayout();
+                return;
+            }
+        }
+        throw new Error(`Invalid direction - ${direction}`);
+    }
+
+    setRatios(ratios) {
+        if (ratios === null) {return;}
+
+        if (!(ratios instanceof Array)) {
+            throw new Error(`ratios must be an array - ${ratios}`);
+        }
+
+        let sumRatios = ratios.reduce((sum, ratio) => {
+            return sum + (typeof ratio === 'number' ? ratio : 0);
+        }, 0);
+
+        this._ratios = ratios;
+        this._proportions = ratios.map((ratio) => {
+            return (typeof ratio === 'number') ? (ratio / sumRatios) : ratio;
+        });
+
+        this._updateLayout();
+    }
+
+    setTransition(transition) {
+        this._transition = transition;
+    }
+}
+
+FlexibleLayout.Direction = {
+    X: Symbol('FlexibleLayout.Direction.X'),
+    Y: Symbol('FlexibleLayout.Direction.Y'),
+    Z: Symbol('FlexibleLayout.Direction.Z')
+};
+
+FamousFramework.registerCustomFamousNodeConstructors({
+    FlexibleLayout: FlexibleLayout
+});

--- a/lib/core-components/famous/layouts/flexible/flexible.js
+++ b/lib/core-components/famous/layouts/flexible/flexible.js
@@ -1,0 +1,53 @@
+FamousFramework.component('famous:layouts:flexible', {
+    behaviors: {
+        '$self' : {
+            'direction' : '[[identity]]',
+            'ratios' : '[[identity]]',
+            'transition' : '[[identity]]'
+        },
+        '.flexible-layout': {
+            // HACK: force creating a layout wrapper container
+            'style': {}
+        },
+        '.flexible-layout-item': {
+            '$yield': true
+        }
+    },
+    events: {
+        '$public': {
+            direction: '[[setter]]',
+            ratios: '[[setter]]',
+            transition: '[[setter]]'
+        },
+        '$private' : {
+            direction($famousNode, $payload) {
+                if ($payload === 0) {
+                    $famousNode.setDirection(FlexibleLayout.Direction.X);
+                } else if ($payload === 1) {
+                    $famousNode.setDirection(FlexibleLayout.Direction.Y);
+                } else if ($payload === 2) {
+                    $famousNode.setDirection(FlexibleLayout.Direction.Z);
+                }
+            },
+            ratios($famousNode, $payload) {
+                $famousNode.setRatios($payload);
+            },
+            transition($famousNode, $payload) {
+                $famousNode.setTransition($payload);
+            }
+        }
+    },
+    states: {
+        direction: 0,
+        ratios: [],
+        transition: null
+    },
+    tree: `
+        <node class="flexible-layout">
+            <node class="flexible-layout-item"></node>
+        </node>
+    `
+}).config({
+    famousNodeConstructorName: 'FlexibleLayout',
+    includes: ['_constructor.js']
+});


### PR DESCRIPTION
This PR adds **Flexible Layout** to the collection of famous core components that will be part of foundational layouts.

* `famous:layouts:flexible`

It exposes the following events with a goal to support similar functionality as `FlexibleLayout` from `Famous v0.3`:
* `direction`: 0 for horizontal, 1 for vertical
* `ratios`: array of values with either `true` to take user-defined size or a number for proportion value
* `transition`: a transition object to use on layout updates

This PR also adds some example components under the `famous-demos:layouts:flexible` namespace:

* `famous-demos:layouts:flexible:simple`
* `famous-demos:layouts:flexible:header-footer`
* `famous-demos:layouts:flexible:nested`
* `famous-demos:layouts:flexible:transition`

---

### Running Examples

#### famous-demos:layouts:flexible:simple

    npm run local-only-bootstrap -- -e famous-demos:layouts:flexible:simple

[http://localhost:1618/?ff=famous-demos:layouts:flexible:simple&navigation=false&search=false](http://localhost:1618/?ff=famous-demos:layouts:flexible:simple&navigation=false&search=false)

#### famous-demos:layouts:flexible:header-footer
    npm run local-only-bootstrap -- -e famous-demos:layouts:flexible:header-footer
[http://localhost:1618/?ff=famous-demos:layouts:flexible:header-footer&navigation=false&search=false](http://localhost:1618/?ff=famous-demos:layouts:flexible:header-footer&navigation=false&search=false)

#### famous-demos:layouts:flexible:nested
    npm run local-only-bootstrap -- -e famous-demos:layouts:flexible:nested
[http://localhost:1618/?ff=famous-demos:layouts:flexible:nested&navigation=false&search=false](http://localhost:1618/?ff=famous-demos:layouts:flexible:nested&navigation=false&search=false)

#### famous-demos:layouts:flexible:transition
    npm run local-only-bootstrap -- -e famous-demos:layouts:flexible:transition
[http://localhost:1618/?ff=famous-demos:layouts:flexible:transition&navigation=false&search=false](http://localhost:1618/?ff=famous-demos:layouts:flexible:transition&navigation=false&search=false)