### PR TITLE
Halt previous transitions when updating flexible layout

### DIFF
--- a/lib/core-components/famous/layouts/flexible/_constructor.js
+++ b/lib/core-components/famous/layouts/flexible/_constructor.js
@@ -88,6 +88,7 @@ class FlexibleLayout extends Node {
             let size = sizes[idx];
             let transition = this._transition;
 
+            childNode._layoutSize.halt();
             childNode._layoutSize.setMode.apply(childNode._layoutSize, [1, 1, 1]);
             childNode._layoutSize.setAbsolute.apply(
                 childNode._layoutSize,
@@ -98,6 +99,8 @@ class FlexibleLayout extends Node {
                     transition
                 ])
             );
+
+            childNode._layoutPosition.halt();
             childNode._layoutPosition.set.apply(
                 childNode._layoutPosition,
                 this._createArrayWithValueAtDirectionIndex(position, [0, 0, 0, transition])


### PR DESCRIPTION
Halt previous transitions when updating flexible layout for better user experience.