### PR TITLE
Add Sequential Layout w/ examples

### DIFF
--- a/lib/core-components/famous-demos/layouts/sequential/simple/simple.js
+++ b/lib/core-components/famous-demos/layouts/sequential/simple/simple.js
@@ -1,0 +1,61 @@
+const COLORS = ['#990000', '#009900', '#000099', '#999900', '#990099'];
+const SIZES = [100, 70, 250, 100, 200];
+
+FamousFramework.component('famous-demos:layouts:sequential:simple', {
+    behaviors: {
+        'famous:layouts:sequential': {
+            'direction': 0
+        },
+        '.item': {
+            'style': {
+                'color': '#fff'
+            }
+        },
+        '.item.one': {
+            'content': `${SIZES[0]}px`,
+            'size-absolute-x': SIZES[0],
+            'style': {
+                'background-color': COLORS[0]
+            }
+        },
+        '.item.two': {
+            'content': `${SIZES[1]}px`,
+            'size-absolute-x': SIZES[1],
+            'style': {
+                'background-color': COLORS[1]
+            }
+        },
+        '.item.three': {
+            'content': `${SIZES[2]}px`,
+            'size-absolute-x': SIZES[2],
+            'style': {
+                'background-color': COLORS[2]
+            }
+        },
+        '.item.four': {
+            'content': `${SIZES[3]}px`,
+            'size-absolute-x': SIZES[3],
+            'style': {
+                'background-color': COLORS[3]
+            }
+        },
+        '.item.five': {
+            'content': `${SIZES[4]}px`,
+            'size-absolute-x': SIZES[4],
+            'style': {
+                'background-color': COLORS[4]
+            }
+        }
+    },
+    events: {},
+    states: {},
+    tree: `
+        <famous:layouts:sequential>
+            <node class="item one"></node>
+            <node class="item two"></node>
+            <node class="item three"></node>
+            <node class="item four"></node>
+            <node class="item five"></node>
+        </famous:layouts:sequential>
+    `
+});

--- a/lib/core-components/famous/layouts/sequential/_constructor.js
+++ b/lib/core-components/famous/layouts/sequential/_constructor.js
@@ -1,0 +1,103 @@
+const Node = FamousFramework.FamousEngine.core.Node;
+const Position = FamousFramework.FamousEngine.components.Position;
+const Size = FamousFramework.FamousEngine.components.Size;
+
+class SequentialLayout extends Node {
+    constructor() {
+        super();
+
+        this._sizeSet = false;
+        this._direction = SequentialLayout.Direction.X;
+        this._transition = null;
+
+        this.addComponent({
+            onSizeChange: () => {
+                this._sizeSet = true;
+                this.updateLayout();
+            }
+        });
+    }
+
+    _getDirectionIndex() {
+        if (this._direction === SequentialLayout.Direction.X) {
+            return 0;
+        } else if (this._direction === SequentialLayout.Direction.Y) {
+            return 1;
+        } else if (this._direction === SequentialLayout.Direction.Z) {
+            return 2;
+        }
+        throw new Error(`Unknown direction - ${this._direction}`);
+    }
+
+    _createArrayWithValueAtDirectionIndex(array, value) {
+        let result = Array.prototype.slice.call(array, 0);
+        let directionIndex = this._getDirectionIndex();
+        result[directionIndex] = value;
+        return result;
+    }
+
+    _getNodeSizes(nodes) {
+        let directionIndex = this._getDirectionIndex();
+        return nodes.map((node, idx) => {
+            let contentNode = nodes[idx].getChildren()[0];
+            return contentNode.getAbsoluteSize()[directionIndex];
+        });
+    }
+
+    _getNodePosition(node) {
+        if (!node._layoutPosition) {
+            node._nodePosition = new Position(node);
+        }
+        return node._nodePosition;
+    }
+
+    _getNodeSize(node) {
+        if (!node._layoutSize) {
+            node._nodeSize = new Size(node);
+        }
+        return node._nodeSize;
+    }
+
+    updateLayout() {
+        if (!this._sizeSet) {return;}
+
+        let createArray = this._createArrayWithValueAtDirectionIndex.bind(this);
+        let childNodes = this.getChildren()[0].getChildren();
+        let sizes = this._getNodeSizes(childNodes);
+        let position = 0;
+
+        childNodes.forEach((childNode, idx) => {
+            let size = sizes[idx];
+            let transition = this._transition;
+
+            let nodePosition = this._getNodePosition(childNode);
+            nodePosition.halt();
+            nodePosition.set.apply(nodePosition, createArray([0, 0, 0], position).concat(transition));
+
+            position += size;
+        });
+    }
+
+    set direction(direction) {
+        for (let key in SequentialLayout.Direction) {
+            if (SequentialLayout.Direction[key] === direction) {
+                this._direction = direction;
+                this.updateLayout();
+                return;
+            }
+        }
+        throw new Error(`Invalid direction - ${direction}`);
+    }
+
+    set transition(transition) {
+        this._transition = transition;
+    }
+}
+
+SequentialLayout.Direction = {
+    X: Symbol('SequentialLayout.Direction.X'),
+    Y: Symbol('SequentialLayout.Direction.Y'),
+    Z: Symbol('SequentialLayout.Direction.Z')
+};
+
+FamousFramework.registerCustomFamousNodeConstructors({SequentialLayout});

--- a/lib/core-components/famous/layouts/sequential/sequential.js
+++ b/lib/core-components/famous/layouts/sequential/sequential.js
@@ -1,0 +1,50 @@
+FamousFramework.component('famous:layouts:sequential', {
+    behaviors: {
+        '$self' : {
+            'direction' : '[[identity]]',
+            'transition' : '[[identity]]'
+        },
+        '.sequential-layout': {
+            // HACK: force creating a layout wrapper container
+            'style': {}
+        },
+        '.sequential-layout-item': {
+            '$yield': true
+        }
+    },
+    events: {
+        '$public': {
+            'direction': '[[setter]]',
+            'transition': '[[setter]]',
+            'update-layout': ($famousNode) => {
+                $famousNode.updateLayout();
+            }
+        },
+        '$private' : {
+            'direction': ($famousNode, $payload) => {
+                if ($payload === 0) {
+                    $famousNode.direction = SequentialLayout.Direction.X;
+                } else if ($payload === 1) {
+                    $famousNode.direction = SequentialLayout.Direction.Y;
+                } else if ($payload === 2) {
+                    $famousNode.direction = SequentialLayout.Direction.Z;
+                }
+            },
+            'transition': ($famousNode, $payload) => {
+                $famousNode.transition = $payload;
+            }
+        }
+    },
+    states: {
+        direction: 0,
+        transition: null
+    },
+    tree: `
+        <node class="sequential-layout">
+            <node class="sequential-layout-item"></node>
+        </node>
+    `
+}).config({
+    famousNodeConstructorName: 'SequentialLayout',
+    includes: ['_constructor.js']
+});


### PR DESCRIPTION
This PR adds **Sequential Layout** to the collection of famous core components that will be part of foundational layouts.

* `famous:layouts:sequential`

It exposes the following events with a goal to support similar functionality as `SequentialLayout` from `Famous v0.3`:
* `direction`: 0 for horizontal, 1 for vertical
* `transition`: a transition object to use on layout updates

This PR also adds some example components under the `famous-demos:layouts:sequential` namespace:

* `famous-demos:layouts:sequential:simple`

---

### Running Examples

#### famous-demos:layouts:sequential:simple

    npm run local-only-bootstrap -- -e famous-demos:layouts:sequential:simple

[http://localhost:1618/?ff=famous-demos:layouts:sequential:simple&navigation=false&search=false](http://localhost:1618/?ff=famous-demos:layouts:sequential:simple&navigation=false&search=false)
