### PR TITLE
Removed use of "camel" sugar that is planned to be deprecated.

### DIFF
--- a/lib/core-components/famous-demos/dynamic-list/dynamic-list.js
+++ b/lib/core-components/famous-demos/dynamic-list/dynamic-list.js
@@ -90,7 +90,7 @@ FamousFramework.module('famous-demos:dynamic-list', {
     },
     events: {
         '$public' : {
-            'block-count': '[[setter|camel]]'
+            'block-count': '[[setter|blockCount]]'
         },
         '#toggle-button': {
             'click': function($state) {

--- a/lib/core-components/famous-tests/component-targeting/child/child.js
+++ b/lib/core-components/famous-tests/component-targeting/child/child.js
@@ -11,7 +11,7 @@ FamousFramework.scene('famous-tests:component-targeting:child', {
     },
     events: {
         '$public': {
-            'my-size': '[[setter|camel]]',
+            'my-size': '[[setter|mySize]]',
         }
     },
     states: {

--- a/lib/core-components/famous-tests/control-flow/repeat/repeat.js
+++ b/lib/core-components/famous-tests/control-flow/repeat/repeat.js
@@ -49,9 +49,9 @@ FamousFramework.module('famous-tests:control-flow:repeat', {
     },
     events: {
         '$public': {
-            'row-count' : '[[setter|camel]]',
-            'col-count' : '[[setter|camel]]',
-            'horizontal-offset' : '[[setter|camel]]'
+            'row-count' : '[[setter|rowCount]]',
+            'col-count' : '[[setter|colCount]]',
+            'horizontal-offset' : '[[setter|horizontalOffset]]'
         }
     },
     states: {

--- a/lib/core-components/famous-tests/custom-famous-node/custom-famous-node.js
+++ b/lib/core-components/famous-tests/custom-famous-node/custom-famous-node.js
@@ -14,10 +14,10 @@ FamousFramework.scene('famous-tests:custom-famous-node', {
     },
     events: {
         $public: {
-            'top-padding' : '[[setter|camel]]',
-            'right-padding' : '[[setter|camel]]',
-            'bottom-padding' : '[[setter|camel]]',
-            'left-padding' : '[[setter|camel]]'
+            'top-padding' : '[[setter|topPadding]]',
+            'right-padding' : '[[setter|rightPadding]]',
+            'bottom-padding' : '[[setter|bottomPadding]]',
+            'left-padding' : '[[setter|leftPadding]]'
         },
         '$private' : {
             'top-padding' : function($famousNode, $payload) {

--- a/lib/core-components/famous/adapter/flickr/flickr.js
+++ b/lib/core-components/famous/adapter/flickr/flickr.js
@@ -91,7 +91,7 @@ FamousFramework.scene('famous:adapter:flickr', {
                 //otherwise set our gallery
                 $state.set("gallery", $payload);
             },
-            'api-key': '[[setter|camel]]'
+            'api-key': '[[setter|apiKey]]'
         }
     },
     states: {

--- a/lib/core-components/famous/layouts/header-footer/header-footer.js
+++ b/lib/core-components/famous/layouts/header-footer/header-footer.js
@@ -46,8 +46,8 @@ FamousFramework.module('famous:layouts:header-footer', {
     },
     events: {
         '$public' : {
-            'header-height' : '[[setter|camel]]',
-            'footer-height' : '[[setter|camel]]'
+            'header-height' : '[[setter|headerHeight]]',
+            'footer-height' : '[[setter|footerHeight]]'
         }
     },
     states: {

--- a/lib/core-components/famous/layouts/scroll-view/scroll-view.js
+++ b/lib/core-components/famous/layouts/scroll-view/scroll-view.js
@@ -22,9 +22,9 @@ FamousFramework.scene('famous:layouts:scroll-view', {
     },
     events: {
         $public: {
-            'item-height' : '[[setter|camel]]',
-            'scroll-view-position' : '[[setter|camel]]',
-            'scroll-view-size' : '[[setter|camel]]',
+            'item-height' : '[[setter|itemHeight]]',
+            'scroll-view-position' : '[[setter|scrollViewPosition]]',
+            'scroll-view-size' : '[[setter|scrollViewSize]]',
         }
     },
     states: {


### PR DESCRIPTION
Dropping the use of `camel` sugar from `core-components/` based on a Slack conversation:
> @pilwon Doesn’t `[[setter|camel]]` conflict with `camel` key in `$state`?
> @matthewtoast it would, yes. we should deprecate `camel`